### PR TITLE
Add interactive production simulation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# model_production_simulation
+# Simulador de Produção
+
+Uma ferramenta visual, responsiva e de interface moderna para simular cenários de produção industrial e compreender rapidamente o impacto de diferentes parâmetros operacionais.
+
+## Recursos
+
+- **Interface moderna** com cards, indicadores e visualização dinâmica.
+- **Configuração flexível** de capacidade, turnos, tempos de setup e qualidade.
+- **Gráfico interativo** com atualização instantânea após cada simulação.
+- **Indicadores chave** como utilização, OEE estimado, fluxo médio por hora e sucata gerada.
+
+## Como usar
+
+1. Abra o arquivo `index.html` em seu navegador.
+2. Ajuste os parâmetros no painel de configurações.
+3. Clique em **Simular produção** para atualizar métricas e gráficos.
+4. Utilize o botão **Redefinir** para retornar aos valores padrão.
+
+Nenhuma instalação adicional é necessária, pois todo o código roda localmente no navegador.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,256 @@
+const selectors = {
+  efficiency: document.getElementById('hero-efficiency'),
+  output: document.getElementById('hero-output'),
+  downtime: document.getElementById('hero-downtime'),
+  chipUtilization: document.getElementById('chip-utilization'),
+  chipOee: document.getElementById('chip-oee'),
+  chipThroughput: document.getElementById('chip-throughput'),
+  avgDailyOutput: document.getElementById('avg-daily-output'),
+  totalDowntime: document.getElementById('total-downtime'),
+  scrapAmount: document.getElementById('scrap-amount'),
+  perShiftOutput: document.getElementById('per-shift-output'),
+  chartTag: document.getElementById('chart-tag'),
+  simulateButton: document.getElementById('simulate'),
+  resetButton: document.getElementById('reset'),
+};
+
+const configForm = document.getElementById('config-form');
+let productionChart = null;
+
+function normalizeNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function calculateOEE({ availability, performance, quality }) {
+  const clamp = (v) => Math.max(0, Math.min(1, v));
+  return clamp(availability) * clamp(performance) * clamp(quality);
+}
+
+function formatNumber(value, options = {}) {
+  return new Intl.NumberFormat('pt-BR', options).format(value);
+}
+
+function formatHours(minutes) {
+  const hours = minutes / 60;
+  return `${formatNumber(hours, { maximumFractionDigits: 1 })} h`;
+}
+
+function formatPercentage(value) {
+  return `${formatNumber(value * 100, { maximumFractionDigits: 1 })}%`;
+}
+
+function buildChart(ctx, labels, data) {
+  if (productionChart) {
+    productionChart.destroy();
+  }
+
+  productionChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Unidades produzidas',
+          data,
+          borderColor: '#38bdf8',
+          backgroundColor: 'rgba(56, 189, 248, 0.18)',
+          tension: 0.4,
+          fill: true,
+          pointRadius: 4,
+          pointBackgroundColor: '#0ea5e9',
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        y: {
+          ticks: {
+            color: 'rgba(248, 250, 252, 0.65)',
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.2)',
+          },
+        },
+        x: {
+          ticks: {
+            color: 'rgba(248, 250, 252, 0.65)',
+          },
+          grid: {
+            display: false,
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          display: false,
+        },
+      },
+    },
+  });
+}
+
+function runSimulation(inputs) {
+  const {
+    capacity,
+    shiftHours,
+    plannedDowntime,
+    unplannedProbability,
+    qualityRate,
+    days,
+    shiftsPerDay,
+    setupTime,
+  } = inputs;
+
+  const results = [];
+  let totalDowntimeMinutes = 0;
+  let totalScrap = 0;
+  let totalGood = 0;
+  const minutesPerShift = shiftHours * 60;
+  const baseRuntime = minutesPerShift - plannedDowntime;
+  const qualityFactor = qualityRate / 100;
+  const hourlyCapacity = capacity;
+  const idealThroughput = hourlyCapacity * shiftHours;
+
+  for (let day = 0; day < days; day += 1) {
+    let dayProduction = 0;
+    for (let shift = 0; shift < shiftsPerDay; shift += 1) {
+      const unplannedDowntime = simulateUnplannedDowntime({
+        shiftHours,
+        probability: unplannedProbability,
+        setupTime,
+      });
+
+      const effectiveRuntime = Math.max(baseRuntime - unplannedDowntime.total, 0);
+      const producedUnits = (effectiveRuntime / 60) * hourlyCapacity;
+      const goodUnits = producedUnits * qualityFactor;
+      const scrapUnits = Math.max(producedUnits - goodUnits, 0);
+
+      dayProduction += goodUnits;
+      totalGood += goodUnits;
+      totalScrap += scrapUnits;
+      totalDowntimeMinutes += plannedDowntime + unplannedDowntime.total + unplannedDowntime.setup;
+    }
+
+    results.push({
+      day: day + 1,
+      goodUnits: dayProduction,
+    });
+  }
+
+  const totalShifts = days * shiftsPerDay;
+  const avgDailyOutput = totalGood / days;
+  const perShiftOutput = totalGood / totalShifts;
+  const totalRuntime = totalShifts * minutesPerShift;
+  const utilization = totalRuntime > 0 ? (totalRuntime - totalDowntimeMinutes) / totalRuntime : 0;
+  const performance = perShiftOutput / idealThroughput;
+  const quality = qualityFactor;
+  const oee = calculateOEE({ availability: utilization, performance, quality });
+
+  return {
+    series: results,
+    totalDowntimeMinutes,
+    totalScrap,
+    totalGood,
+    avgDailyOutput,
+    perShiftOutput,
+    utilization,
+    performance,
+    quality,
+    oee,
+    throughputPerHour: perShiftOutput / shiftHours,
+  };
+}
+
+function simulateUnplannedDowntime({ shiftHours, probability, setupTime }) {
+  const hours = Math.max(Math.floor(shiftHours), 1);
+  let total = 0;
+  let setup = 0;
+
+  for (let hour = 0; hour < hours; hour += 1) {
+    const eventRoll = Math.random() * 100;
+    if (eventRoll < probability) {
+      const duration = 5 + Math.random() * 20; // minutos
+      total += duration;
+    }
+  }
+
+  if (total > 0) {
+    setup = setupTime;
+  }
+
+  return { total, setup };
+}
+
+function readInputs() {
+  const data = new FormData(configForm);
+  return {
+    capacity: normalizeNumber(data.get('capacity'), 100),
+    shiftHours: normalizeNumber(data.get('shiftHours'), 8),
+    plannedDowntime: normalizeNumber(data.get('plannedDowntime'), 30),
+    unplannedProbability: normalizeNumber(data.get('unplannedProbability'), 15),
+    qualityRate: normalizeNumber(data.get('qualityRate'), 95),
+    days: normalizeNumber(data.get('days'), 7),
+    shiftsPerDay: normalizeNumber(data.get('shiftsPerDay'), 1),
+    setupTime: normalizeNumber(data.get('setupTime'), 20),
+  };
+}
+
+function updateHero({ utilization, avgDailyOutput, totalDowntimeMinutes }) {
+  selectors.efficiency.textContent = formatPercentage(utilization);
+  selectors.output.textContent = `${formatNumber(avgDailyOutput, {
+    maximumFractionDigits: 0,
+  })} un`;
+  selectors.downtime.textContent = formatHours(totalDowntimeMinutes / Math.max(readInputs().days, 1));
+}
+
+function updateChips({ utilization, oee, throughputPerHour }) {
+  selectors.chipUtilization.textContent = `Utilização ${formatPercentage(utilization)}`;
+  selectors.chipOee.textContent = `OEE ${formatPercentage(oee)}`;
+  selectors.chipThroughput.textContent = `Fluxo ${formatNumber(throughputPerHour, {
+    maximumFractionDigits: 0,
+  })} un/h`;
+}
+
+function updateStats({ avgDailyOutput, totalDowntimeMinutes, totalScrap, perShiftOutput }) {
+  selectors.avgDailyOutput.textContent = `${formatNumber(avgDailyOutput, {
+    maximumFractionDigits: 0,
+  })} unidades`;
+  selectors.totalDowntime.textContent = formatHours(totalDowntimeMinutes);
+  selectors.scrapAmount.textContent = `${formatNumber(totalScrap, {
+    maximumFractionDigits: 0,
+  })} unidades`;
+  selectors.perShiftOutput.textContent = `${formatNumber(perShiftOutput, {
+    maximumFractionDigits: 0,
+  })} unidades`;
+}
+
+function updateChart(series, days) {
+  const labels = series.map((item) => `Dia ${item.day}`);
+  const data = series.map((item) => Math.round(item.goodUnits));
+  selectors.chartTag.textContent = `Últimos ${days} dias`;
+  const canvas = document.getElementById('production-chart').getContext('2d');
+  buildChart(canvas, labels, data);
+}
+
+function simulateAndRender() {
+  const inputs = readInputs();
+  const results = runSimulation(inputs);
+  updateHero({
+    utilization: results.utilization,
+    avgDailyOutput: results.avgDailyOutput,
+    totalDowntimeMinutes: results.totalDowntimeMinutes,
+  });
+  updateChips(results);
+  updateStats(results);
+  updateChart(results.series, inputs.days);
+}
+
+selectors.simulateButton.addEventListener('click', simulateAndRender);
+selectors.resetButton.addEventListener('click', () => {
+  setTimeout(simulateAndRender, 0);
+});
+
+simulateAndRender();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simulador de Produção</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
+    <script src="app.js" defer></script>
+  </head>
+  <body>
+    <div class="page">
+      <header class="hero">
+        <div class="hero__content">
+          <span class="hero__badge">Simulação em tempo real</span>
+          <h1>Planeje sua produção com confiança</h1>
+          <p>
+            Explore cenários, ajuste parâmetros e visualize o impacto no seu
+            desempenho industrial com uma interface intuitiva e responsiva.
+          </p>
+        </div>
+        <div class="hero__panel">
+          <div class="hero__panel__metric">
+            <span class="label">Eficiência estimada</span>
+            <strong id="hero-efficiency">0%</strong>
+          </div>
+          <div class="hero__panel__metric">
+            <span class="label">Produção diária</span>
+            <strong id="hero-output">0 un</strong>
+          </div>
+          <div class="hero__panel__metric">
+            <span class="label">Tempo ocioso</span>
+            <strong id="hero-downtime">0 h</strong>
+          </div>
+        </div>
+      </header>
+
+      <main class="layout">
+        <section class="card card--inputs">
+          <h2>Configurações da linha</h2>
+          <form id="config-form" class="form-grid">
+            <label class="field">
+              <span>Capacidade nominal (un/h)</span>
+              <input
+                type="number"
+                id="capacity"
+                name="capacity"
+                min="10"
+                step="10"
+                value="180"
+                required
+              />
+            </label>
+            <label class="field">
+              <span>Duração do turno (h)</span>
+              <input
+                type="number"
+                id="shift-hours"
+                name="shiftHours"
+                min="4"
+                max="24"
+                step="1"
+                value="8"
+                required
+              />
+            </label>
+            <label class="field">
+              <span>Intervalos planejados (min)</span>
+              <input
+                type="number"
+                id="planned-downtime"
+                name="plannedDowntime"
+                min="0"
+                step="5"
+                value="40"
+              />
+            </label>
+            <label class="field">
+              <span>Probabilidade de parada não planejada (%)</span>
+              <input
+                type="number"
+                id="unplanned-probability"
+                name="unplannedProbability"
+                min="0"
+                max="100"
+                step="1"
+                value="25"
+              />
+            </label>
+            <label class="field">
+              <span>Qualidade média (%)</span>
+              <input
+                type="number"
+                id="quality-rate"
+                name="qualityRate"
+                min="50"
+                max="100"
+                step="1"
+                value="95"
+              />
+            </label>
+            <label class="field">
+              <span>Dias a simular</span>
+              <input
+                type="number"
+                id="days"
+                name="days"
+                min="1"
+                max="30"
+                value="7"
+              />
+            </label>
+            <label class="field">
+              <span>Número de turnos/dia</span>
+              <input
+                type="number"
+                id="shifts-per-day"
+                name="shiftsPerDay"
+                min="1"
+                max="4"
+                value="2"
+              />
+            </label>
+            <label class="field">
+              <span>Tempo médio de setup (min)</span>
+              <input
+                type="number"
+                id="setup-time"
+                name="setupTime"
+                min="0"
+                step="5"
+                value="30"
+              />
+            </label>
+            <div class="form-grid__actions">
+              <button type="button" id="simulate" class="button button--primary">
+                Simular produção
+              </button>
+              <button type="reset" id="reset" class="button button--ghost">
+                Redefinir
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section class="card card--results">
+          <div class="results-header">
+            <h2>Resumo dos resultados</h2>
+            <div class="chips">
+              <span class="chip" id="chip-utilization">Utilização 0%</span>
+              <span class="chip" id="chip-oee">OEE 0%</span>
+              <span class="chip" id="chip-throughput">Fluxo 0 un/h</span>
+            </div>
+          </div>
+          <div class="stats-grid">
+            <article class="stat">
+              <h3>Produção média diária</h3>
+              <p id="avg-daily-output">0 unidades</p>
+            </article>
+            <article class="stat">
+              <h3>Tempo ocioso total</h3>
+              <p id="total-downtime">0 horas</p>
+            </article>
+            <article class="stat">
+              <h3>Sucata gerada</h3>
+              <p id="scrap-amount">0 unidades</p>
+            </article>
+            <article class="stat">
+              <h3>Produtividade por turno</h3>
+              <p id="per-shift-output">0 unidades</p>
+            </article>
+          </div>
+          <div class="chart-card">
+            <div class="chart-card__header">
+              <h3>Volume produzido por dia</h3>
+              <span class="chart-card__tag" id="chart-tag">Últimos 7 dias</span>
+            </div>
+            <canvas id="production-chart" height="220"></canvas>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,306 @@
+:root {
+  color-scheme: light dark;
+  --background: #0f172a;
+  --surface: rgba(15, 23, 42, 0.65);
+  --surface-strong: rgba(15, 23, 42, 0.85);
+  --text: #f8fafc;
+  --muted: rgba(248, 250, 252, 0.7);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --positive: #22c55e;
+  --negative: #f87171;
+  --radius: 18px;
+  --shadow:
+    0 20px 45px rgba(15, 23, 42, 0.45),
+    0 4px 12px rgba(15, 23, 42, 0.25);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.18), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.25), transparent 45%),
+    radial-gradient(circle at 0% 100%, rgba(96, 165, 250, 0.25), transparent 50%),
+    #020617;
+  color: var(--text);
+  min-height: 100vh;
+  padding: 40px clamp(16px, 4vw, 72px);
+}
+
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.hero {
+  display: flex;
+  gap: clamp(24px, 6vw, 60px);
+  align-items: stretch;
+  justify-content: space-between;
+}
+
+.hero__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 13px;
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  line-height: 1.05;
+  font-weight: 700;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  color: var(--muted);
+  max-width: 520px;
+}
+
+.hero__panel {
+  flex: 1;
+  display: grid;
+  gap: 16px;
+  padding: 24px;
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  align-content: center;
+}
+
+.hero__panel__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hero__panel__metric .label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.hero__panel__metric strong {
+  font-size: 2.2rem;
+  font-weight: 700;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card h2 {
+  font-size: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field span {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.field input {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 12px 16px;
+  color: var(--text);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.form-grid__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.button {
+  border-radius: 12px;
+  border: 1px solid transparent;
+  padding: 12px 20px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #0f172a;
+  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.35);
+}
+
+.button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(14, 165, 233, 0.4);
+}
+
+.button--ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.3);
+  color: var(--muted);
+}
+
+.button--ghost:hover {
+  border-color: rgba(148, 163, 184, 0.5);
+}
+
+.results-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.chips {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  padding: 8px 14px;
+  background: rgba(56, 189, 248, 0.16);
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 20px;
+}
+
+.stat {
+  background: var(--surface-strong);
+  border-radius: 16px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.stat h3 {
+  font-size: 1rem;
+  color: var(--muted);
+}
+
+.stat p {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.chart-card {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.chart-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.chart-card__tag {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    flex-direction: column;
+  }
+
+  .hero__panel {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 32px 18px;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-grid__actions {
+    justify-content: stretch;
+  }
+
+  .button {
+    flex: 1;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- create a modern single-page interface for simular cenários de produção
- add interactive chart and KPI cards fed by a lightweight simulation engine
- document how to use the simulator and run it locally via browser

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ceed550483268c60d1b682543135